### PR TITLE
Add arguments for parallelization to differential_expression and residualized_counts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
 RoxygenNote: 7.1.1
 biocViews:
 Imports:
+    BiocParallel,
     biomaRt,
     cqn,
     data.table,
@@ -53,6 +54,7 @@ Imports:
     magrittr,
     mclust,
     mvIC,
+    parallel,
     plyr,
     psych,
     purrr,

--- a/R/functions.R
+++ b/R/functions.R
@@ -515,14 +515,14 @@ build_formula <- function(md, primary_variable, model_variables = NULL,
 #' Differential expression testing is performed with \code{"variancePartition::dream()"} to increase power
 #' and decrease false positives for repeated measure designs. The `primary_variable` is modeled as a fixed
 #' effect. If you wish to test an interaction term, `primary_variable` can take multiple variable names.
-#' 
+#'
 #' @param cqn_counts A counts data frame normalized by CQN.
 #' @param p_value_threshold Numeric. P-values are adjusted by Benjamini and
 #' Hochberg (BH) false discovery rate (FDR). Significant genes are those with an
 #' adjusted p-value greater than this threshold.
 #' @param fold_change_threshold Numeric. Significant genes are those with a
 #' fold-change greater than this threshold.
-#' @param cores An integer of cores to specify in the parallel backend (eg. 4)
+#' @param cores An integer of cores to specify in the parallel backend (eg. 4).
 #' @inheritParams cqn
 #' @inheritParams coerce_factors
 #' @inheritParams build_formula

--- a/R/functions.R
+++ b/R/functions.R
@@ -633,7 +633,7 @@ differential_expression <- function(filtered_counts, cqn_counts, md,
 #' @export
 wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
                     biomart_results, p_value_threshold, fold_change_threshold,
-                    model_variables = names(md)) {
+                    model_variables = names(md), cores = NULL) {
   purrr::map(
     conditions,
     function(x) differential_expression(
@@ -644,7 +644,8 @@ wrap_de <- function(conditions, filtered_counts, cqn_counts, md,
       biomart_results,
       p_value_threshold,
       fold_change_threshold,
-      model_variables
+      model_variables,
+      cores = cores
       )
     )
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -549,7 +549,9 @@ differential_expression <- function(filtered_counts, cqn_counts, md,
   gene_expression <- edgeR::calcNormFactors(gene_expression)
   voom_gene_expression <- variancePartition::voomWithDreamWeights(counts = gene_expression,
                                                                   formula = metadata_input$formula,
-                                                                  data = metadata_input$metadata)
+                                                                  data = metadata_input$metadata,
+                                                                  BPPARAM = BiocParallel::SnowParam(parallel::detectCores()-1)
+                                                                 )
   voom_gene_expression$E <- cqn_counts
 
   de_conditions <- levels(metadata_input$metadata[[metadata_input$primary_variable]])
@@ -580,7 +582,8 @@ differential_expression <- function(filtered_counts, cqn_counts, md,
   fit_contrasts = variancePartition::dream(exprObj = voom_gene_expression,
                                            formula = metadata_input$formula_non_intercept,
                                            data = metadata_input$metadata,
-                                           L = contrasts
+                                           L = contrasts,
+                                           BPPARAM = BiocParallel::SnowParam(parallel::detectCores()-1) 
                                            )
 
   de <- lapply(names(contrasts), function(i, fit){
@@ -986,7 +989,8 @@ compute_residuals <- function(clean_metadata, filtered_counts,
   voom <- variancePartition::voomWithDreamWeights(
     counts = gene_expression,
     formula = metadata_input$formula,
-    data = metadata_input$metadata
+    data = metadata_input$metadata,
+    BPPARAM = BiocParallel::SnowParam(parallel::detectCores()-1)
   )
 
   # fit linear model using weights and best model
@@ -995,7 +999,8 @@ compute_residuals <- function(clean_metadata, filtered_counts,
     exprObj = voom,
     formula = metadata_input$formula,
     data = metadata_input$metadata,
-    computeResiduals = TRUE
+    computeResiduals = TRUE,
+    BPPARAM = BiocParallel::SnowParam(parallel::detectCores()-1)
   )
 
   # compute residual matrix

--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,7 @@ default:
   cpm threshold: 1
   percent threshold: 0.5
   sex check: sex
+  cores: 
   dimensions:
     color: "diagnosis"
     shape: "batch"

--- a/inst/_targets.R
+++ b/inst/_targets.R
@@ -142,7 +142,8 @@ list(
         filtered_counts,
         cqn_counts = cqn_counts$E,
         primary_variable = x,
-        model_variables = selected_model
+        model_variables = selected_model,
+        cores = get("cores")
         )
       )
     ),
@@ -156,7 +157,8 @@ list(
       biomart_results,
       p_value_threshold = get("de p-value threshold"),
       fold_change_threshold = get("de FC"),
-      model_variables = selected_model
+      model_variables = selected_model,
+      cores = get("cores")
     )
   ),
   tar_target(

--- a/man/compute_residuals.Rd
+++ b/man/compute_residuals.Rd
@@ -9,7 +9,8 @@ compute_residuals(
   filtered_counts,
   cqn_counts = cqn_counts$E,
   primary_variable,
-  model_variables = NULL
+  model_variables = NULL,
+  cores = NULL
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ fixed effect interaction term.}
 
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}
+
+\item{cores}{An integer of cores to specify in the parallel backend (eg. 4).}
 }
 \description{
 Residuals of the best fit linear regression model are computed for each

--- a/man/differential_expression.Rd
+++ b/man/differential_expression.Rd
@@ -13,7 +13,8 @@ differential_expression(
   p_value_threshold,
   fold_change_threshold,
   model_variables = NULL,
-  exclude_variables = NULL
+  exclude_variables = NULL,
+  cores = NULL
 )
 }
 \arguments{
@@ -40,6 +41,8 @@ fold-change greater than this threshold.}
 If not supplied, the model will include all variables in \code{md}.}
 
 \item{exclude_variables}{Vector of variables to exclude from testing.}
+
+\item{cores}{An integer of cores to specify in the parallel backend (eg. 4).}
 }
 \value{
 A named list with \code{"variancePartition::voomWithDreamWeights()"}

--- a/man/wrap_de.Rd
+++ b/man/wrap_de.Rd
@@ -12,7 +12,8 @@ wrap_de(
   biomart_results,
   p_value_threshold,
   fold_change_threshold,
-  model_variables = names(md)
+  model_variables = names(md),
+  cores = NULL
 )
 }
 \arguments{
@@ -37,6 +38,8 @@ fold-change greater than this threshold.}
 
 \item{model_variables}{Optional. Vector of variables to include in the linear (mixed) model.
 If not supplied, the model will include all variables in \code{md}.}
+
+\item{cores}{An integer of cores to specify in the parallel backend (eg. 4).}
 }
 \description{
 This function will pass multiple conditions to test to \code{"sagseqr::differential_expression()"}.

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -72,7 +72,7 @@ cores:            Optional. Specify an integer of cores to use with a BiocParall
                   parallel backend.  Null value results in the number of available
                   cores minus one being used. Parallel backend ccurrently only supports
                   BiocParallel::SnowParam(). BatchtoolsParam, MulticoreParam, 
-                  BiocParallelDoparParam, and SerialParam not currently supported.
+                  BiocParallelDoparParam, and SerialParam are not currently supported.
 de FC:            The fold-change (FC) of significant differentially expressed 
                   (de) genes must exceed this value. This value will be transformed
                   into log2 FC.

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -68,6 +68,11 @@ skip model:       Optional. If TRUE, the exploratory data report is run. Model s
                   is not computed.
 force model with: Optional. Force differential expression with this user defined model
                   instead of the output of stepwise regression.
+cores:            Optional. Specify an integer of cores to use with a BiocParallel 
+                  parallel backend.  Null value results in the number of available
+                  cores minus one being used. Parallel backend ccurrently only supports
+                  BiocParallel::SnowParam(). BatchtoolsParam, MulticoreParam, 
+                  BiocParallelDoparParam, and SerialParam not currently supported.
 de FC:            The fold-change (FC) of significant differentially expressed 
                   (de) genes must exceed this value. This value will be transformed
                   into log2 FC.


### PR DESCRIPTION
Fixes #152. Added `BPPARAM = BiocParallel::SnowParam(parallel::detectCores()-1)` to `variancePartition::dream` and `variancePartition::voomWithDreamWeights` function calls.